### PR TITLE
remove ES6 syntax

### DIFF
--- a/app/assets/javascripts/channels/messages.js
+++ b/app/assets/javascripts/channels/messages.js
@@ -13,20 +13,7 @@ App.messages = App.cable.subscriptions.create('MessagesChannel', {
     received: function (data) {
       // Called when there's incoming data on the websocket for this channel. You could put plain jQuery into here to replace a div with html, for example.
       document.querySelector('#messages').classList.remove('hidden')
-      let content = `
-      <div class="message-container">
-            <div class="avatar-wrapper">
-              <img class="message-avatar" src="http://placehold.it/100/100">
-              <p>
-                ${data.user}
-              </p>
-            </div>
-            <div class="message-text-balloon">
-              ${data.message}
-            </div>
-          </div>
-          `
+      let content = "<div class='message-container'><div class='avatar-wrapper'><img class='message-avatar' src='http://placehold.it/100/100'><p>" + data.user + "</p></div><div class='message-text-balloon'>" + data.message + "</div></div>"
       return document.querySelector('#messages').insertAdjacentHTML('beforeend', content);
-
     }
 });


### PR DESCRIPTION
We needed to remove the new ES6 syntax from the old JS pipeline because we were using it for the chat function, which used a tutorial that referenced the old asset pipeline. All good